### PR TITLE
Benchmarks: Don't export WORLD_SIZE when using MPI

### DIFF
--- a/torch/lib/THD/benchmark/run_benchmark
+++ b/torch/lib/THD/benchmark/run_benchmark
@@ -153,7 +153,7 @@ if [ x"$BACKEND" = xtcp ]; then
     wait
 elif [ x"$BACKEND" = xmpi ]; then
     . "$environment"
-    export BACKEND MASTER_ADDR MASTER_PORT WORLD_SIZE
+    export BACKEND MASTER_ADDR MASTER_PORT
     mpirun -hosts "$hosts" -n "$WORLD_SIZE" >> ${output_file:-} \
         python "$engine" \
         ${min_num_tensors:-} ${min_bytes:-} ${max_num_tensors:-} ${max_bytes:-}

--- a/torch/lib/THD/benchmark/run_benchmark
+++ b/torch/lib/THD/benchmark/run_benchmark
@@ -153,7 +153,7 @@ if [ x"$BACKEND" = xtcp ]; then
     wait
 elif [ x"$BACKEND" = xmpi ]; then
     . "$environment"
-    export BACKEND MASTER_ADDR MASTER_PORT
+    export BACKEND
     mpirun -hosts "$hosts" -n "$WORLD_SIZE" >> ${output_file:-} \
         python "$engine" \
         ${min_num_tensors:-} ${min_bytes:-} ${max_num_tensors:-} ${max_bytes:-}


### PR DESCRIPTION
I just realized we don't need it (any longer?).